### PR TITLE
deployment github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+# Copyright 2024 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: janusgraph-python-deployment
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Pack
+      run: |
+        python -m build
+    - name: Store the distribution package
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distribution
+        path: dist/
+
+  pypi-publish:
+    name: Upload release to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/janusgraphpython
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution package
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distribution
+          path: dist/
+      - name: Publish package distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR contains the github action for building the python package and publishing it to PyPI. The proposed name for the JanusGraph-Python package is "janusgraphpython" following the naming convention of the Gremlin-Python package called "gremlinpython".