### PR TITLE
cleaning unused pytest-cov package from requirements

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,2 @@
 pytest==7.4.3
-pytest-cov==4.1.0
 testcontainers==3.7.1


### PR DESCRIPTION
Related to PR #49. This is a fix to clean pytest-cov package from requirements.